### PR TITLE
Add SpellCast to the default applications

### DIFF
--- a/src/DiscordTogether.js
+++ b/src/DiscordTogether.js
@@ -12,6 +12,7 @@ const defaultApplications = {
   lettertile: '879863686565621790',
   wordsnack: '879863976006127627',
   doodlecrew: '878067389634314250',
+  spellcast: '852509694341283871',
 };
 
 /**


### PR DESCRIPTION
# Description

Added SpellCast to the default applications list

# How Has This Been Tested?

I attempted to launch SpellCast on my own discord bot and it worked.

**Test Configuration**:
* Operating system: Windows 11
* Node version: 16.10.0
* NPM version: 7.24.0
